### PR TITLE
Adjustments for volumetric update

### DIFF
--- a/cdFBA/__init__.py
+++ b/cdFBA/__init__.py
@@ -14,6 +14,8 @@ def volumetric_update(schema, current, update, top_schema, top_state, path, core
     new_counts = current["counts"]
     new_concentrations = current["concentrations"]
 
+    import ipdb; ipdb.set_trace()
+
     if ('_add' in update.keys()) or ('_remove' in update.keys()):
         for name in update["_add"].keys():
             new_counts[name] = update["_add"][name]

--- a/cdFBA/__init__.py
+++ b/cdFBA/__init__.py
@@ -9,32 +9,32 @@ def apply_non_negative(schema, current, update, core):
 def set_update(schema, current, update, top_schema, top_state, path, core):
     return update
 
+def conditional_apply(schema, current, update, key, core):
+    if key in update:
+        applied = core.apply(
+            schema[key],
+            current[key],
+            update[key])
+    else:
+        applied = current[key]
+
+    return applied
+
 def volumetric_update(schema, current, update, top_schema, top_state, path, core):
-    volume = current.get("volume")
-    new_counts = current["counts"]
-    new_concentrations = current["concentrations"]
+    updated_counts = conditional_apply(schema, current, update, 'counts', core)
+    updated_volume = conditional_apply(schema, current, update, 'volume', core)
+    updated_concentrations = {}
 
-    import ipdb; ipdb.set_trace()
+    for key, counts in updated_counts.items():
+        updated_concentrations[key] = counts / updated_volume
 
-    if ('_add' in update.keys()) or ('_remove' in update.keys()):
-        for name in update["_add"].keys():
-            new_counts[name] = update["_add"][name]
-            new_concentrations[name] = update["_add"][name]/volume
-        for name in update["_remove"]:
-            new_counts.pop(name)
-            new_concentrations.pop(name)
-
-    for key, value in update["counts"].items():
-        if (key != "_add") and (key != "_remove"):
-            new = new_counts[key] + value
-            new_counts[key] = new
-            new_concentrations[key] = new/volume
-
-    return {
-        "counts": new_counts,
-        "concentrations": new_concentrations,
-        "volume": volume,
+    applied = {
+        'counts': updated_counts,
+        'concentrations': updated_concentrations,
+        'volume': updated_volume,
     }
+    
+    return applied
 
 positive_float = {
     "_type": "positive_float",

--- a/cdFBA/processes/dfba.py
+++ b/cdFBA/processes/dfba.py
@@ -108,13 +108,13 @@ class UpdateEnvironment(Step):
 
     def inputs(self):
         return {
-             "shared_environment": "volumetric",
-             "species_updates": "map[map[set_float]]",
+            "shared_environment": "volumetric",
+            "species_updates": "map[map[set_float]]",
         }
 
     def outputs(self):
         return {
-            "shared_environment": "map[float]",
+            "counts": "map[float]",
         }
 
     def update(self, inputs):
@@ -135,7 +135,7 @@ class UpdateEnvironment(Step):
                     update[substrate_id] = -shared_environment[substrate_id]
 
         return {
-            "shared_environment": {"counts": update}
+            "counts": update
         }
 
 class StaticConcentration(Process):

--- a/cdFBA/processes/dfbalauncher.py
+++ b/cdFBA/processes/dfbalauncher.py
@@ -31,8 +31,8 @@ class EnvironmentMonitor(Step):
     def outputs(self):
         return {
             "new_species": "map",
-            "counts": "map",
-            "shared_environment": "map",
+            "counts": "map[float]",
+            # "shared_environment": "map",
             "dfba_results": "any",
         }
 
@@ -76,29 +76,39 @@ class EnvironmentMonitor(Step):
                     # remove_concentrations.append(name)
                     remove_dfba_updates.append(name)
 
-        environment_updates = {
-            '_add': add_dfba_updates,
-            '_remove': remove_dfba_updates,
-        }
-        environment_updates.update(mass_updates)
+        # environment_updates = {
+        #     '_add': add_dfba_updates,
+        #     '_remove': remove_dfba_updates,
+        # }
+        # environment_updates.update(mass_updates)
 
         # if to_add:
         #     import ipdb; ipdb.set_trace()
-        return {
+
+        counts_updates = {
+            '_add': add_counts,
+            '_remove': remove_counts,
+        }
+
+        counts_updates.update(mass_updates)
+
+        update = {
             "new_species": {
                 '_add': to_add,
                 '_remove': to_remove
             },
-            "shared_environment": {
-                '_add': add_counts,
-                '_remove': remove_counts,
-            },
+            "counts": counts_updates,
             "dfba_results": {
                 '_add': add_dfba_updates,
                 '_remove': remove_dfba_updates,
             },
-            "mass_removal": {"counts": mass_updates}
+            # "mass_removal": {"counts": mass_updates}
         }
+
+        if add_counts:
+            import ipdb; ipdb.set_trace()
+
+        return update
 
 def get_env_monitor_spec(interval):
     """Returns a specification dictionary for the environment monitor"""
@@ -115,9 +125,9 @@ def get_env_monitor_spec(interval):
         "outputs": {
             "new_species": [SPECIES_STORE],
             # "concentrations": [SHARED_ENVIRONMENT, "concentrations"],
-            "shared_environment": [SHARED_ENVIRONMENT],
+            # "shared_environment": [SHARED_ENVIRONMENT],
             "dfba_results": [DFBA_RESULTS],
-            "mass_removal": [SHARED_ENVIRONMENT],
+            "counts": [SHARED_ENVIRONMENT, "counts"],
         },
     }
 

--- a/cdFBA/processes/dfbalauncher.py
+++ b/cdFBA/processes/dfbalauncher.py
@@ -32,7 +32,6 @@ class EnvironmentMonitor(Step):
         return {
             "new_species": "map",
             "counts": "map[float]",
-            # "shared_environment": "map",
             "dfba_results": "any",
         }
 
@@ -76,15 +75,6 @@ class EnvironmentMonitor(Step):
                     # remove_concentrations.append(name)
                     remove_dfba_updates.append(name)
 
-        # environment_updates = {
-        #     '_add': add_dfba_updates,
-        #     '_remove': remove_dfba_updates,
-        # }
-        # environment_updates.update(mass_updates)
-
-        # if to_add:
-        #     import ipdb; ipdb.set_trace()
-
         counts_updates = {
             '_add': add_counts,
             '_remove': remove_counts,
@@ -102,11 +92,7 @@ class EnvironmentMonitor(Step):
                 '_add': add_dfba_updates,
                 '_remove': remove_dfba_updates,
             },
-            # "mass_removal": {"counts": mass_updates}
         }
-
-        if add_counts:
-            import ipdb; ipdb.set_trace()
 
         return update
 
@@ -124,8 +110,6 @@ def get_env_monitor_spec(interval):
         },
         "outputs": {
             "new_species": [SPECIES_STORE],
-            # "concentrations": [SHARED_ENVIRONMENT, "concentrations"],
-            # "shared_environment": [SHARED_ENVIRONMENT],
             "dfba_results": [DFBA_RESULTS],
             "counts": [SHARED_ENVIRONMENT, "counts"],
         },

--- a/cdFBA/utils.py
+++ b/cdFBA/utils.py
@@ -454,7 +454,7 @@ def environment_spec():
             "shared_environment": [SHARED_ENVIRONMENT]
         },
         "outputs": {
-            "shared_environment": [SHARED_ENVIRONMENT],
+            "counts": [SHARED_ENVIRONMENT, "counts"],
         }
     }
 


### PR DESCRIPTION
Hey @sniffo, here's an update to make everything run.... (you will also need to update `bigraph-schema` and `process-bigraph`). There are two main changes here:

* Updates to the volumetric update
* adjustments to schemas to make them line up more (or minimize their scope)

About the volumetric update - `_add` and `_remove` are actually features of the `map` type.... at some point I will be explaining all of this, but in the meantime one way to think of it is we can't add anything to a `float` for instance, only certain types are "_add"-able, as it were. In this case just maps. 
When you add a new `_apply` method you are overriding any apply methods that may be further down the tree. This is why you ended up having to replicate the functionality that already existed in `map` to `_add` and `_remove` things in the counts etc. Instead we can just delegate that application to the subkey we are adding to (in this case `counts`) since the `volumetric` type knows it has a `counts` key that is a `map[float]` type. I did the same thing with `volume` - then derived the `concentrations` from those two (which I think was the original intention for making the `volumetric` type CMIIW). 
In general apply methods of complex types need to take into account how application will flow down the tree. I think in this case we might want to add additional logic to update the counts according to the volume if only the concentrations were updated? I know it's not in this use case perhaps but would generalize to others where the concentrations are being updated instead of the counts (?)

The changes I made to different input and output schemas are to align the types (the volumetric type was sometimes just getting called a map, for instance, or in some places the "shared_environment" showed up as a map, but really it had a bunch of submaps and wasn't getting keys added/removed directly etc) or to minimize scope (some places there were outputs for the whole "Shared Environment" but only `counts` was being updated - it is cleaner (?) to not include things that aren't being directly updated). 
Some of the motivation here is that though the type system will try to reconcile as much as possible and work with what you throw it, it helps if everything is as consistent as we can make it. 
A theoretical aside: I think this is a part of the whole system with kind of unbounded room for improvement - how do you merge two different type descriptions of the same underlying state in a general way? I think in some places it makes sense to use `any` or `map` (which intentionally leaves out the type parameter) and allow other parts of the system to declare the specific constraints - I see you do that in a few places here. The type system will resolve it with by choosing the type that is the most specific, so usually `any` just gets replaced by whatever else ends up there.... as long as it gets specified _somewhere_. 
That said we should try to avoid things like declaring something a type like `volumetric` in one place but `map` in another - it's possible but ends up confusing the various methods - you get a mix of map and volumetric as none of these "supersede" the other. Again I can think of various strategies to improve this with different tradeoffs....
Still evolving how all this should work and your feedback/efforts here are appreciated!